### PR TITLE
send notification when post published

### DIFF
--- a/classes/ColdTrick/BlogTools/Cron.php
+++ b/classes/ColdTrick/BlogTools/Cron.php
@@ -87,6 +87,11 @@ class Cron {
 			// publish blog
 			$entity->status = "published";
 			
+			// revert access
+			$entity->access_id = $entity->future_access;
+			unset($entity->future_access);
+			
+			
 			// send notifications when post published
 			elgg_trigger_event('publish', 'object', $entity);
 

--- a/classes/ColdTrick/BlogTools/Cron.php
+++ b/classes/ColdTrick/BlogTools/Cron.php
@@ -86,6 +86,9 @@ class Cron {
 
 			// publish blog
 			$entity->status = "published";
+			
+			// send notifications when post published
+			elgg_trigger_event('publish', 'object', $entity);
 
 			// notify owner
 			notify_user($entity->getOwnerGUID(),


### PR DESCRIPTION
In save action of blog plugin an event triggers when a post is published. but this event doesn't triggers 
for the blog published with advanced publication options (e.g. cron).